### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/devopsGH/254b7e10-3636-43c4-a68a-ce0933af49ee/d55d409f-a430-4fa2-8648-1c77e262b1a9/_apis/work/boardbadge/3f033a2a-8020-41ca-8f98-63728471945c)](https://dev.azure.com/devopsGH/254b7e10-3636-43c4-a68a-ce0933af49ee/_boards/board/t/d55d409f-a430-4fa2-8648-1c77e262b1a9/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/devopsGH/254b7e10-3636-43c4-a68a-ce0933af49ee/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.